### PR TITLE
Use new group name for dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,17 +24,17 @@ scikit-learn = "^1.1"
 spacy = "^3.4.1"
 tabulate = "^0.8.10"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^22.8"
 flake8 = "^5.0.4"
+flake8-pytest-style = "^1.7.2"
 isort = "^5.12.0"
 mypy = "^0.981"
+nox = "^2022.8.7"
 pytest = "^7.1.3"
 pytest-cov = "^4.0.0"
-nox = "^2022.8.7"
-types-tabulate = "^0.8.11"
 pyupgrade = "^2.38.2"
-flake8-pytest-style = "^1.7.2"
+types-tabulate = "^0.8.11"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
`dev-dependencies` is deprecated since Poetry 1.2.0 and now a separate group named `dev` should be used. Additionally, the list of dev dependencies has been sorted.